### PR TITLE
Fix dnf package count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hayabusa"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "base64",
  "clap",
@@ -1763,9 +1763,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ee1aca2bc74ef9589efa7ccaa0f3752751399940356209b3fd80c078149b5e"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hayabusa"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 license-file = "LICENSE.md"

--- a/src/daemon/package_managers.rs
+++ b/src/daemon/package_managers.rs
@@ -119,7 +119,7 @@ pub(crate) async fn get_pacman_package_count() -> Result<u64, String> {
 
 pub(crate) async fn get_dnf_package_count() -> Result<u64, String> {
     let output: Output = Command::new("dnf")
-        .arg("list")
+        .args(["list", "--installed"])
         .output()
         .map_err(|e| e.to_string())?;
 


### PR DESCRIPTION
Hayabusa intends to report *installed* packages, but the Fedora command used actually fetches all of them, installed or not, making the result both incorrect and unnecessarily expensive on the daemon.

It might be worth checking the other package managers.

From `man dnf-list`:

```bash
EXAMPLES
       dnf5 list
              List installed and available packages.
```

Package count using `dnf list`:

```bash
❯ dnf list | wc -l
Updating and loading repositories:
Repositories loaded.
77970
```

Time taken by `dnf list`:

```bash
❯ hyperfine 'dnf list'
Benchmark 1: dnf list
  Time (mean ± σ):      1.854 s ±  0.068 s    [User: 1.658 s, System: 0.262 s]
  Range (min … max):    1.780 s …  2.010 s    10 runs
```

The easiest fix is to add the `--installed` option.

Package count using `dnf list --installed`:

```bash
❯ dnf list --installed | wc -l
2504
```

Time taken by `dnf list --installed`:

```bash
❯ hyperfine 'dnf list --installed'
Benchmark 1: dnf list --installed
  Time (mean ± σ):     560.5 ms ±  17.5 ms    [User: 410.0 ms, System: 142.0 ms]
  Range (min … max):   538.5 ms … 595.1 ms    10 runs
```

# rpm

I think the ideal would be to use `rpm -qa` ("lower level" interface) instead.

From `man rpm`:

```bash
   PACKAGE SELECTION OPTIONS

       ...

       -a, --all [SELECTOR]
              Query all installed packages.
```

- If I understand it correctly, it also lists packages that might not be counted by dnf.
- Performance-wise, it's similar enough that I don't think it should be a consideration. 
- Additionally, it would obviate the `count -= 1` since only packages are printed.

But I don't actually know that rpm is always available when dnf is. Feels like it would be, but I can't back that up.

Just fixing the package count is already a good start, so I'm not worried about making the perfect choice immediately.